### PR TITLE
fix: add api id to stack outputs

### DIFF
--- a/src/documentation.js
+++ b/src/documentation.js
@@ -129,7 +129,7 @@ module.exports = function(AWS) {
 
     _buildDocumentation: function _buildDocumentation(result) {
       this.restApiId = result.Stacks[0].Outputs
-        .filter(output => output.OutputKey === 'ApiId')
+        .filter(output => output.OutputKey === 'AwsDocApiId')
         .map(output => output.OutputValue)[0];
 
       this.getGlobalDocumentationParts();

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,14 @@ class ServerlessAWSDocumentation {
       const func = this.serverless.service.getFunction(functionName);
       func.events.forEach(this.updateCfTemplateFromHttp.bind(this));
     });
+
+    // Add models
+    this.cfTemplate.Outputs.AwsDocApiId = {
+      Description: 'API ID',
+      Value: {
+        Ref: 'ApiGatewayRestApi',
+      },
+    };
   }
 
   afterDeploy() {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -27,7 +27,8 @@ describe('ServerlessAWSDocumentation', function() {
               ExistingResource: {
                 with: 'configuration',
               },
-            }
+            },
+            Outputs: {},
           }
         },
         getFunction: jasmine.createSpy('getFunction').and.callFake((functionName) => {
@@ -135,6 +136,14 @@ describe('ServerlessAWSDocumentation', function() {
             with: 'configuration',
           },
         },
+        Outputs: {
+          AwsDocApiId: {
+            Description: 'API ID',
+            Value: {
+              Ref: 'ApiGatewayRestApi',
+            },
+          }
+        },
       });
     });
 
@@ -161,6 +170,14 @@ describe('ServerlessAWSDocumentation', function() {
           ExistingResource: {
             with: 'configuration',
           },
+        },
+        Outputs: {
+          AwsDocApiId: {
+            Description: 'API ID',
+            Value: {
+              Ref: 'ApiGatewayRestApi',
+            },
+          }
         },
       });
     });
@@ -277,6 +294,14 @@ describe('ServerlessAWSDocumentation', function() {
             }
           },
         },
+        Outputs: {
+          AwsDocApiId: {
+            Description: 'API ID',
+            Value: {
+              Ref: 'ApiGatewayRestApi',
+            },
+          }
+        },
       });
     });
 
@@ -354,6 +379,14 @@ describe('ServerlessAWSDocumentation', function() {
             }
           },
         },
+        Outputs: {
+          AwsDocApiId: {
+            Description: 'API ID',
+            Value: {
+              Ref: 'ApiGatewayRestApi',
+            },
+          }
+        },
       });
     });
 
@@ -421,6 +454,14 @@ describe('ServerlessAWSDocumentation', function() {
               // },
             }
           },
+        },
+        Outputs: {
+          AwsDocApiId: {
+            Description: 'API ID',
+            Value: {
+              Ref: 'ApiGatewayRestApi',
+            },
+          }
         },
       });
     });
@@ -533,6 +574,14 @@ describe('ServerlessAWSDocumentation', function() {
             },
           },
         },
+        Outputs: {
+          AwsDocApiId: {
+            Description: 'API ID',
+            Value: {
+              Ref: 'ApiGatewayRestApi',
+            },
+          }
+        },
       });
     });
 
@@ -587,6 +636,14 @@ describe('ServerlessAWSDocumentation', function() {
             some: 'other_configuration',
             Properties: {},
           },
+        },
+        Outputs: {
+          AwsDocApiId: {
+            Description: 'API ID',
+            Value: {
+              Ref: 'ApiGatewayRestApi',
+            },
+          }
         },
       });
     });
@@ -750,7 +807,7 @@ describe('ServerlessAWSDocumentation', function() {
             OutputKey: 'ApiKey',
             OutputValue: 'nothing',
           }, {
-            OutputKey: 'ApiId',
+            OutputKey: 'AwsDocApiId',
             OutputValue: 'superid',
           }],
         }],


### PR DESCRIPTION
The API ID was not set in the outputs. Therefore setting documentation didn't worked without adding the output manually. Now it is added automatically so this manual step isn't needed any more.

Fixes #9 