### PR TITLE
fixed problem with missing response headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-aws-documentation",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Serverless 1.0 plugin to add documentation and models to the serverless generated API Gateway",
   "main": "src/index.js",
   "scripts": {

--- a/src/models.js
+++ b/src/models.js
@@ -31,6 +31,14 @@ module.exports = {
           ResponseModels: response.responseModels,
         };
 
+        if(response.responseHeaders){
+          const methodResponseHeaders = {};
+          response.responseHeaders.forEach(header => {
+            methodResponseHeaders[`method.response.header.${header.name}`] = true
+          });
+          _response.ResponseParameters = methodResponseHeaders;
+        }
+
         this.addModelDependencies(_response.ResponseModels, resource);
         resource.Properties.MethodResponses.push(_response);
       });


### PR DESCRIPTION
Hi guys.
You developed great plug-in.
I've tried it on my project.
I have requirement to have input and output models.
But when I had specified response model I faced problem.    
I spent 4 hours for troubleshooting with that problem [Invalid mapping expression parameter specified: method.response.header.Content-Type].
Only after comparing cloudformation file I noticed that you dot not apply responseHeaders to ResponseParameters.    