### PR TITLE
fix: solve problem with potentially existing method responses and new ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-aws-documentation",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Serverless 1.0 plugin to add documentation and models to the serverless generated API Gateway",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.js",
   "scripts": {
     "codecov": "cat coverage/*/lcov.info | codecov",
-    "test": "istanbul cover -x \"src/index.spec.js\" jasmine ./src/index.spec.js"
+    "test": "istanbul cover -x \"src/index.spec.js\" jasmine ./src/index.spec.js",
+    "test:nocoverage": "jasmine ./src/index.spec.js"
   },
   "repository": "9cookies/serverless-aws-documentation",
   "author": "Simon Jentsch <simon.jentsch@9cookies.com> (https://twitter.com/tchockie)",

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -305,7 +305,7 @@ describe('ServerlessAWSDocumentation', function () {
       });
     });
 
-    it('should only add response methods whith existence MethodResponses to ApiGateway methods', function () {
+    it('should only add response methods with existing MethodResponses to ApiGateway methods', function () {
       this.serverlessMock.variables.service.custom.documentation.models = [];
       this.serverlessMock.service._functionNames = ['test'];
       this.serverlessMock.service._functions = {
@@ -343,10 +343,174 @@ describe('ServerlessAWSDocumentation', function () {
         Properties: {
           MethodResponses: [{
             StatusCode: 200,
+            id: 9001,
           },
           {
             StatusCode: 404,
+            id: 9002,
           }],
+        },
+      };
+
+      this.plugin.beforeDeploy();
+
+      expect(this.serverlessMock.service.provider.compiledCloudFormationTemplate).toEqual({
+        Resources: {
+          ExistingResource: {
+            with: 'configuration',
+          },
+          somepath_post: {
+            some: 'configuration',
+            DependsOn: ['CreateResponseModel', 'ErrorResponseModel'],
+            Properties: {
+              MethodResponses: [{
+                StatusCode: 200,
+                id: 9001,
+                ResponseModels: {
+                  'application/json': 'CreateResponse',
+                },
+              },
+              {
+                StatusCode: 404,
+                id: 9002,
+                ResponseModels: {
+                  'application/json': 'ErrorResponse'
+                },
+              }],
+            },
+          },
+        },
+        Outputs: {
+          AwsDocApiId: {
+            Description: 'API ID',
+            Value: {
+              Ref: 'ApiGatewayRestApi',
+            },
+          }
+        },
+      });
+    });
+
+    it('should only add response methods with existing and new MethodResponses to ApiGateway methods', function () {
+      this.serverlessMock.variables.service.custom.documentation.models = [];
+      this.serverlessMock.service._functionNames = ['test'];
+      this.serverlessMock.service._functions = {
+        test: {
+          events: [{
+            http: {
+              path: 'some/path',
+              method: 'post',
+              cors: true,
+              private: true,
+              documentation: {
+                methodResponses: [
+                  {
+                    statusCode: 200,
+                    should: 'not be included',
+                    responseModels: {
+                      'application/json': 'CreateResponse',
+                    },
+                  },
+                  {
+                    statusCode: 404,
+                    should: 'not be included',
+                    responseModels: {
+                      'application/json': 'ErrorResponse'
+                    },
+                  },
+                ],
+              }
+            },
+          }],
+        },
+      };
+
+      const resources = this.serverlessMock.service.provider.compiledCloudFormationTemplate.Resources;
+      resources.somepath_post = {
+        some: 'configuration',
+        Properties: {
+          MethodResponses: [{
+            StatusCode: 200,
+            id: 9001,
+          },],
+        },
+      };
+
+      this.plugin.beforeDeploy();
+
+      expect(this.serverlessMock.service.provider.compiledCloudFormationTemplate).toEqual({
+        Resources: {
+          ExistingResource: {
+            with: 'configuration',
+          },
+          somepath_post: {
+            some: 'configuration',
+            DependsOn: ['CreateResponseModel', 'ErrorResponseModel'],
+            Properties: {
+              MethodResponses: [{
+                StatusCode: 200,
+                id: 9001,
+                ResponseModels: {
+                  'application/json': 'CreateResponse',
+                },
+              },
+              {
+                StatusCode: 404,
+                ResponseModels: {
+                  'application/json': 'ErrorResponse'
+                },
+              }],
+            },
+          },
+        },
+        Outputs: {
+          AwsDocApiId: {
+            Description: 'API ID',
+            Value: {
+              Ref: 'ApiGatewayRestApi',
+            },
+          }
+        },
+      });
+    });
+
+    it('should only add response methods with existing empty MethodResponses to ApiGateway methods', function () {
+      this.serverlessMock.variables.service.custom.documentation.models = [];
+      this.serverlessMock.service._functionNames = ['test'];
+      this.serverlessMock.service._functions = {
+        test: {
+          events: [{
+            http: {
+              path: 'some/path',
+              method: 'post',
+              cors: true,
+              private: true,
+              documentation: {
+                methodResponses: [
+                  {
+                    statusCode: 200,
+                    responseModels: {
+                      'application/json': 'CreateResponse',
+                    },
+                  },
+                  {
+                    statusCode: 404,
+                    responseModels: {
+                      'application/json': 'ErrorResponse'
+                    },
+                  },
+                ],
+              }
+            },
+          }],
+        },
+      };
+
+      const resources = this.serverlessMock.service.provider.compiledCloudFormationTemplate.Resources;
+      resources.somepath_post = {
+        some: 'configuration',
+        Properties: {
+          MethodResponses: [],
         },
       };
 

--- a/src/models.js
+++ b/src/models.js
@@ -23,22 +23,17 @@ module.exports = {
 
   addMethodResponses: function addMethodResponses(resource, documentation) {
     if (documentation.methodResponses) {
-      if (resource.Properties.MethodResponses) {
-        resource.Properties.MethodResponses.forEach(originalResponse => {
-          documentation.methodResponses.forEach(response => {
-            if (originalResponse.StatusCode === response.statusCode) {
-              originalResponse.ResponseModels = response.responseModels;
-              this.addModelDependencies(originalResponse.ResponseModels, resource);
-            }
-          });
-        });
-      } else {
+      if (!resource.Properties.MethodResponses) {
         resource.Properties.MethodResponses = [];
+      }
 
-        documentation.methodResponses.forEach(response => {
-          const _response = {
+      documentation.methodResponses.forEach(response => {
+        let _response = resource.Properties.MethodResponses
+          .find(originalResponse => originalResponse.StatusCode === response.statusCode);
+
+        if (!_response) {
+          _response = {
             StatusCode: response.statusCode,
-            ResponseModels: response.responseModels
           };
 
           if (response.responseHeaders) {
@@ -49,10 +44,12 @@ module.exports = {
             _response.ResponseParameters = methodResponseHeaders;
           }
 
-          this.addModelDependencies(_response.ResponseModels, resource);
           resource.Properties.MethodResponses.push(_response);
-        });
-      }
+        }
+
+        _response.ResponseModels = response.responseModels;
+        this.addModelDependencies(_response.ResponseModels, resource);
+      });
     }
   },
 


### PR DESCRIPTION
The problem was, that the change in 0.5.6 didn't account an already existing ResponseMethods array with completely different entries.

Now mixed existing and new ones are possible. 
Like response 200 and 400 are existing, and in the documentation part 200 and 404 are described, but not 400.

Also potentially empty existing MethodeResponses array should be no problem

fixes #17 