### PR TITLE
responseModels isn't mandatory in responseMethods

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -47,8 +47,10 @@ module.exports = {
           resource.Properties.MethodResponses.push(_response);
         }
 
-        _response.ResponseModels = response.responseModels;
-        this.addModelDependencies(_response.ResponseModels, resource);
+        if (response.responseModels) {
+          _response.ResponseModels = response.responseModels;
+          this.addModelDependencies(_response.ResponseModels, resource);
+        }
       });
     }
   },


### PR DESCRIPTION
This pull request enables one to have `methodResponses` without a `responseModels` section.

Example:

```
            methodResponses:
              - statusCode: '204'
                description: The server successfully processed the request and is not returning any content.
                responseBody:
                  description: No body returned
                responseHeaders:
                  - name: Access-Control-Allow-Origin

```