### PR TITLE
Should be able to document without models

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,17 +29,19 @@ class ServerlessAWSDocumentation {
   }
 
   beforeDeploy() {
-    if (!(this.customVars && this.customVars.documentation && this.customVars.documentation.models)) return;
+    if (!(this.customVars && this.customVars.documentation)) return;
 
     this.cfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
 
-    // Add model resources
-    const models = this.customVars.documentation.models.map(this.createCfModel)
-      .reduce((modelObj, model) => {
-        modelObj[`${model.Properties.Name}Model`] = model;
-        return modelObj;
-      }, {});
-    Object.assign(this.cfTemplate.Resources, models);
+    if (this.customVars.documentation.models) {
+      // Add model resources
+      const models = this.customVars.documentation.models.map(this.createCfModel)
+        .reduce((modelObj, model) => {
+          modelObj[`${model.Properties.Name}Model`] = model;
+          return modelObj;
+        }, {});
+      Object.assign(this.cfTemplate.Resources, models);
+    }
 
     // Add models to method resources
     this.serverless.service.getAllFunctions().forEach(functionName => {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -100,10 +100,25 @@ describe('ServerlessAWSDocumentation', function () {
       expect(this.serverlessMock.service.getAllFunctions).not.toHaveBeenCalled();
     });
 
-    it('shouldn\'t do anything if there are no models in custom variables', function () {
+    it('should work even if there are no models in custom variables', function () {
       delete this.plugin.customVars.documentation.models;
       this.plugin.beforeDeploy();
-      expect(this.serverlessMock.service.getAllFunctions).not.toHaveBeenCalled();
+      expect(this.serverlessMock.service.getAllFunctions).toHaveBeenCalled();
+      expect(this.serverlessMock.service.provider.compiledCloudFormationTemplate).toEqual({
+        Resources: {
+          ExistingResource: {
+            with: 'configuration',
+          },
+        },
+        Outputs: {
+          AwsDocApiId: {
+            Description: 'API ID',
+            Value: {
+              Ref: 'ApiGatewayRestApi',
+            },
+          }
+        },
+      });
     });
 
     it('should add models but not add them to http events', function () {

--- a/src/models.js
+++ b/src/models.js
@@ -47,8 +47,10 @@ module.exports = {
           resource.Properties.MethodResponses.push(_response);
         }
 
-        _response.ResponseModels = response.responseModels;
-        this.addModelDependencies(_response.ResponseModels, resource);
+        if (response.responseModels) {
+          _response.ResponseModels = response.responseModels;
+          this.addModelDependencies(_response.ResponseModels, resource);
+        }
       });
     }
   },


### PR DESCRIPTION
Not all services require a model, but if there's no model then the Api ID isn't added to the outputs, which means that the `afterDeploy` fails. This pull request allows for documentation to be deployed by `afterDeploy` even if there are no models documented.