### PR TITLE
fixes #51 adds support for the swagger 'tags' property on methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ described in your `serverless.yml`. Inside the `http` event of your functions yo
 * `queryParams`: A list of query parameters (needs `name` of the parameter)
 * `pathParams`: A list of path parameters (needs `name` of the parameter)
 * `methodResponses`: A list of method responses (needs the `statusCode` of the response)
+* `tags`: A list of tags apply to the `METHOD`, which is the HTTP event in serverless. Used in [Swagger-UI](https://swagger.io/swagger-ui/)
 
 The methodResponses itself can have the following parts:
 
@@ -144,6 +145,9 @@ createItem:
         documentation:
           summary: "Create something"
           description: "Creates the thing you need"
+          tags:
+            - "Data Creation"
+            - "Some other tag"
           requestBody:
             description: "Request body description"
           requestHeaders:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ custom:
     version: '1'
     summary: 'My API'
     description: 'This is my API'
+    tags:
+      -
+        name: 'Data Creation'
+        description: 'Services to create things'
+      -
+        name: 'Some other tag'
+        description: 'A tag for other things'
     authorizers:
       -
         name: "MyCustomAuthorizer"
@@ -80,9 +87,9 @@ In there you also can manually describe the version (needs to be a string). If y
 version, the version that API Gateway needs will automatically be generated. This auto version is a
 hash of the documentation you defined, so if you don't change your documentation, the documentation
 in API Gateway won't be touched.
-Underneath you can define `authorizers`, `resources` and `models` which are all lists of descriptions.
+Underneath you can define `tags`, `authorizers`, `resources` and `models` which are all lists of descriptions.
 In addition to the description and the summary, Authorizers need the name of the authorizer, resources
-need the path of the described resource and models need the name of the model.
+need the path of the described resource and models need the name of the model. Tags provides the description for tags that are used on `METHOD`s (HTTP events), [more info here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#tag-object).
 
 
 ### Define the models

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "codecov": "cat coverage/*/lcov.info | codecov",
-    "test": "istanbul cover -x \"src/index.spec.js\" jasmine ./src/index.spec.js",
+    "test": "istanbul cover -x \"src/index.spec.js\" jasmine ./src/index.spec.js ./src/documentation.spec.js",
     "test:nocoverage": "jasmine ./src/index.spec.js"
   },
   "repository": "9cookies/serverless-aws-documentation",

--- a/src/documentation.js
+++ b/src/documentation.js
@@ -2,14 +2,12 @@
 
 const objectHash = require('object-hash');
 
-const documentationProperties = ['description', 'summary', 'tags'];
-
 const globalDocumentationParts = require('./globalDocumentationParts.json');
 const functionDocumentationParts = require('./functionDocumentationParts.json');
 
-function  getDocumentationProperties(def) {
+function getDocumentationProperties(def, propertiesToGet) {
   const docProperties = new Map();
-  documentationProperties.forEach((key) => {
+  propertiesToGet.forEach((key) => {
     if (def[key]) {
       docProperties.set(key, def[key]);
     }
@@ -26,6 +24,24 @@ function _mapToObj(map) {
   return returnObj;
 }
 
+/*
+ * Different types support different extra properties beyond
+ * the basic ones, so we need to make sure we only look for
+ * the appropriate properties.
+ */
+function determinePropertiesToGet (type) {
+  const defaultProperties = ['description', 'summary']
+  let result = defaultProperties
+  switch (type) {
+    case 'API':
+    case 'METHOD':
+      result.push('tags')
+      break
+  }
+  return result
+
+}
+
 var autoVersion;
 
 module.exports = function() {
@@ -36,8 +52,9 @@ module.exports = function() {
         return loc;
       }, {});
       location.type = part.type;
+      const propertiesToGet = determinePropertiesToGet(location.type)
 
-      const props = getDocumentationProperties(def);
+      const props = getDocumentationProperties(def, propertiesToGet);
       if (props.size > 0) {
         this.documentationParts.push({
           location,
@@ -121,7 +138,6 @@ module.exports = function() {
       const globalDocumentation = this.customVars.documentation;
       this.createDocumentationParts(globalDocumentationParts, globalDocumentation, {});
     },
-
 
     getFunctionDocumentationParts: function getFunctionDocumentationParts() {
       const httpEvents = this._getHttpEvents();
@@ -231,6 +247,8 @@ module.exports = function() {
           delete resource.DependsOn;
         }
       }
-    }
+    },
+
+    _getDocumentationProperties: getDocumentationProperties
   };
 };

--- a/src/documentation.js
+++ b/src/documentation.js
@@ -2,7 +2,7 @@
 
 const objectHash = require('object-hash');
 
-const documentationProperties = ['description', 'summary'];
+const documentationProperties = ['description', 'summary', 'tags'];
 
 const globalDocumentationParts = require('./globalDocumentationParts.json');
 const functionDocumentationParts = require('./functionDocumentationParts.json');

--- a/src/documentation.spec.js
+++ b/src/documentation.spec.js
@@ -1,0 +1,143 @@
+describe('ServerlessAWSDocumentation', function () {
+
+  const objectUnderTest = require('./documentation.js')()
+
+  beforeEach(() => {
+    objectUnderTest.documentationParts = []
+    objectUnderTest.restApiId = 'testApiId'
+  })
+
+  describe('_createDocumentationPart', () => {
+    it('should include the tags property for an API part', () => {
+      let part = {
+        type: 'API',
+        isList: false,
+        locationProps: []
+      }
+      let def = {
+        description: 'the desc',
+        summary: 'the summary',
+        tags: ['tag1']
+      }
+      let knownLocation = {}
+      objectUnderTest._createDocumentationPart(part, def, knownLocation)
+      let result = objectUnderTest.documentationParts
+      expect(result.length).toBe(1)
+      expect(result).toEqual([
+        {
+          location: {
+            type: 'API'
+          },
+          properties: {
+            description: 'the desc',
+            summary: 'the summary',
+            tags: ['tag1']
+          },
+          restApiId: 'testApiId'
+        }
+      ])
+    })
+
+    it('should include the tags property for a METHOD part', () => {
+      let part = {
+        type: 'METHOD',
+        isList: false,
+        locationProps: ['path', 'method'],
+        children: {}
+      }
+      let def = {
+        description: 'the desc',
+        summary: 'the summary',
+        tags: ['tag1']
+      }
+      let knownLocation = {
+        path: '/some/path',
+        method: 'GET'
+      }
+      objectUnderTest._createDocumentationPart(part, def, knownLocation)
+      let result = objectUnderTest.documentationParts
+      expect(result.length).toBe(1)
+      expect(result).toEqual([
+        {
+          location: {
+            type: 'METHOD',
+            path: '/some/path',
+            method: 'GET'
+          },
+          properties: {
+            description: 'the desc',
+            summary: 'the summary',
+            tags: ['tag1']
+          },
+          restApiId: 'testApiId'
+        }
+      ])
+    })
+
+    it('should not include the tags property for a REQUEST_BODY part (actually anything other than API or METHOD)', () => {
+      let part = {
+        type: 'QUERY_PARAMETER',
+        isList: true,
+        locationProps: ['path', 'method', 'name']
+      }
+      let def = {
+        description: 'the desc',
+        summary: 'the summary',
+        tags: ['tag1'] // should be ignored
+      }
+      let knownLocation = {
+        path: '/some/path',
+        method: 'GET',
+        name: 'someParam'
+      }
+      objectUnderTest._createDocumentationPart(part, def, knownLocation)
+      let result = objectUnderTest.documentationParts
+      expect(result.length).toBe(1)
+      expect(result).toEqual([
+        {
+          location: {
+            type: 'QUERY_PARAMETER',
+            path: '/some/path',
+            method: 'GET',
+            name: 'someParam'
+          },
+          properties: {
+            description: 'the desc',
+            summary: 'the summary'
+          },
+          restApiId: 'testApiId'
+        }
+      ])
+    })
+  })
+
+  describe('getDocumentationProperties', () => {
+    it('should include the tags property when we indicate to include it', () => {
+      let def = {
+        description: 'the desc',
+        summary: 'the summary',
+        tags: ['tag1']
+      }
+      let propertiesToGet = ['description', 'summary', 'tags']
+      let result = objectUnderTest._getDocumentationProperties(def, propertiesToGet)
+      expect(result.size).toBe(3)
+      expect(result.get('description')).toBe('the desc')
+      expect(result.get('summary')).toBe('the summary')
+      expect(result.get('tags')).toEqual(['tag1'])
+    })
+
+    it('should ignore a defined tag when we indicate to not include it', () => {
+      let def = {
+        description: 'the desc',
+        summary: 'the summary',
+        tags: ['tag1']
+      }
+      let propertiesToGet = ['description', 'summary'] // no 'tags'
+      let result = objectUnderTest._getDocumentationProperties(def, propertiesToGet)
+      expect(result.size).toBe(2)
+      expect(result.get('description')).toBe('the desc')
+      expect(result.get('summary')).toBe('the summary')
+      expect(result.get('tags')).toBeUndefined()
+    })
+  })
+})

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1553,6 +1553,10 @@ describe('ServerlessAWSDocumentation', function () {
     it('should build documentation with deploying and upload to api gateway', function (done) {
       this.serverlessMock.variables.service.custom.documentation.api = {
         description: 'this is an api',
+        tags: [
+          {name: 'tag1', description: 'First tag'},
+          {name: 'tag2', description: 'Second tag'}
+        ]
       };
       this.serverlessMock.variables.service.custom.documentation.authorizers = [{
         name: 'an-authorizer',
@@ -1736,7 +1740,13 @@ describe('ServerlessAWSDocumentation', function () {
           'createDocumentationPart',
           {
             location: { type: 'API' },
-            properties: JSON.stringify({ description: 'this is an api' }),
+            properties: JSON.stringify({
+              description: 'this is an api',
+              tags: [
+                {name: 'tag1', description: 'First tag'},
+                {name: 'tag2', description: 'Second tag'}
+              ]
+            }),
             restApiId: 'superid',
           }
         );
@@ -2220,7 +2230,7 @@ describe('ServerlessAWSDocumentation', function () {
       });
     });
 
-    it('should not do anything if an list documentation part is not an array', function (done) {
+    it('should not do anything if a list documentation part is not an array', function (done) {
       spyOn(console, 'info');
       this.serverlessMock.variables.service.custom.documentation.models = {
         this: 'is wrong',

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1580,6 +1580,7 @@ describe('ServerlessAWSDocumentation', function () {
                 summary: 'hello',
                 description: 'hello hello',
                 unknownProperty: 'should not be displayed',
+                tags: ['tag1', 'tag2'],
                 requestBody: {
                   description: 'is it me',
                 },
@@ -1805,7 +1806,7 @@ describe('ServerlessAWSDocumentation', function () {
           'createDocumentationPart',
           {
             location: { path: 'some/path', method: 'POST', type: 'METHOD' },
-            properties: JSON.stringify({ description: 'hello hello', summary: 'hello' }),
+            properties: JSON.stringify({ description: 'hello hello', summary: 'hello', tags: ['tag1', 'tag2'] }),
             restApiId: 'superid',
           }
         );


### PR DESCRIPTION
Added support for the `tags` property. This fixes https://github.com/9cookies/serverless-aws-documentation/issues/51