### PR TITLE
Include method in object key when collecting HTTP events and allow info element

### DIFF
--- a/src/documentation.js
+++ b/src/documentation.js
@@ -34,6 +34,8 @@ function determinePropertiesToGet (type) {
   let result = defaultProperties
   switch (type) {
     case 'API':
+      result.push('tags', 'info')
+      break
     case 'METHOD':
       result.push('tags')
       break

--- a/src/documentation.js
+++ b/src/documentation.js
@@ -156,7 +156,7 @@ module.exports = function() {
           .filter((eventTypes) => eventTypes.http && eventTypes.http.documentation)
           .map((eventTypes) => eventTypes.http)
           .forEach(currEvent => {
-            let key = functionName + currEvent.path;
+            let key = functionName + currEvent.method + currEvent.path;
             documentationObj[key] = currEvent;
           });
         return documentationObj;


### PR DESCRIPTION
Small fix to the problem that within one Lambda function, multiple HTTP events with the same path but different method were ignored except for the last one, which overwrote the others.