### PR TITLE
use the same type (string) to compare methodResponse statusCode

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -69,7 +69,7 @@ module.exports = {
       documentation.methodResponses.forEach(response => {
         const statusCode = response.statusCode.toString();
         let _response = resource.Properties.MethodResponses
-          .find(originalResponse => originalResponse.StatusCode === statusCode);
+          .find(originalResponse => originalResponse.StatusCode.toString() === statusCode);
 
         if (!_response) {
           _response = {


### PR DESCRIPTION
should use the same type (string) to compare methodResponse statusCode