### PR TITLE
Download documentation from AWS Api Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ ApiGatewayMethod{normalizedPath}{normalizedMethod}:
 
 See the Serverless documentation for more information on [resource naming](https://serverless.com/framework/docs/providers/aws/guide/resources/), and the AWS documentation for more information on [request parameters](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-integration.html#cfn-apigateway-method-integration-requestparameters).
 
-### Download documentation from AWS APi Gateway
+### Download documentation from AWS API Gateway
 
 To download the deployed documentation you just need to use `serverless downloadDocumentation --outputFile=filename.ext`.
 For `yml` or `yaml` extensions application/yaml content will be downloaded from AWS. In any other case - application/json. 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,11 @@ ApiGatewayMethod{normalizedPath}{normalizedMethod}:
 
 See the Serverless documentation for more information on [resource naming](https://serverless.com/framework/docs/providers/aws/guide/resources/), and the AWS documentation for more information on [request parameters](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-integration.html#cfn-apigateway-method-integration-requestparameters).
 
+### Download documentation from AWS APi Gateway
+
+To download the deployed documentation you just need to use `serverless downloadDocumentation --outputFile=filename.ext`.
+For `yml` or `yaml` extensions application/yaml content will be downloaded from AWS. In any other case - application/json. 
+
 ## Contribution
 
 When you think something is missing or found some bug, please add an issue to this repo. If you want

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "codecov": "cat coverage/*/lcov.info | codecov",
-    "test": "istanbul cover -x \"src/index.spec.js\" jasmine ./src/index.spec.js ./src/documentation.spec.js ./src/models.spec.js",
+    "test": "istanbul cover -x \"src/index.spec.js\" jasmine ./src/index.spec.js ./src/documentation.spec.js ./src/models.spec.js ./src/downloadDocumentation.spec.js",
     "test:nocoverage": "jasmine ./src/index.spec.js"
   },
   "repository": "9cookies/serverless-aws-documentation",

--- a/src/downloadDocumentation.js
+++ b/src/downloadDocumentation.js
@@ -1,0 +1,47 @@
+'use strict';
+
+module.exports = {
+  downloadDocumentation: function () {
+    const aws = this.serverless.providers.aws;
+    const stackName = aws.naming.getStackName(this.serverless.service.provider.stage);
+    return this._getRestApiId(stackName).then((restApiId) => {
+      return aws.request('APIGateway', 'getExport', {
+        stageName: this.serverless.service.provider.stage,
+        restApiId: restApiId,
+        exportType: 'swagger',
+        accepts: createAWSContentType(this.options.outputFileName),
+      });
+    }).then((response) => {
+      this.fs.writeFileSync(this.options.outputFileName, response.body);
+    });
+  },
+
+  _getRestApiId: function (stackName) {
+    return this.serverless.providers.aws.request('CloudFormation', 'describeStacks', {StackName: stackName},
+      this.serverless.service.provider.stage,
+      this.serverless.service.provider.region
+    ).then((result) => {
+      return result.Stacks[0].Outputs
+        .filter(output => output.OutputKey === 'AwsDocApiId')
+        .map(output => output.OutputValue)[0];
+    });
+  },
+};
+
+function getFileExtension(filename) {
+  const path = require('path');
+  let ext = path.extname(filename || '').split('.');
+
+  return ext[ext.length - 1];
+}
+
+function createAWSContentType(outputFileName) {
+  const fileExtension = getFileExtension(outputFileName);
+  let awsContentType = 'application/json';
+  if (fileExtension === 'yml' || fileExtension === 'yaml') {
+    awsContentType = 'application/yaml';
+  }
+
+  return awsContentType;
+}
+

--- a/src/downloadDocumentation.spec.js
+++ b/src/downloadDocumentation.spec.js
@@ -1,0 +1,62 @@
+describe('ServerlessAWSDocumentation', function () {
+  const objectUnderTest = require('./downloadDocumentation.js');
+
+  beforeEach(() => {
+    objectUnderTest.restApiId = 'testApiId';
+
+    objectUnderTest.fs = {
+      writeFileSync: jasmine.createSpy('fs')
+    };
+    objectUnderTest.serverless = {
+      providers: {
+        aws: {
+          naming: {
+            getStackName: () => {
+              return 'testStackName';
+            }
+          },
+          request: jasmine.createSpy('aws request'),
+        }
+      },
+      service: {
+        provider: {
+          stage: 'testStage',
+          region: 'testRegion',
+        }
+      }
+    };
+  });
+
+  describe('downloadDocumentation', () => {
+    it('should successfully download documentation', (done) => {
+      objectUnderTest.options = {
+        outputFileName: 'test.json',
+      };
+      objectUnderTest._getRestApiId = () => {
+        return Promise.resolve('testRestApiId')
+      };
+
+      objectUnderTest.serverless.providers.aws.request.and.returnValue(Promise.resolve({
+        body: 'some body',
+      }));
+      return objectUnderTest.downloadDocumentation().then(() => {
+        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.json', 'some body');
+
+        done();
+      });
+    });
+
+    it('should throw an error', (done) => {
+      objectUnderTest.options = {
+        outputFileName: 'test.json',
+      };
+      objectUnderTest._getRestApiId = () => {
+        return Promise.resolve('testRestApiId');
+      };
+      objectUnderTest.serverless.providers.aws.request.and.returnValue(Promise.reject('reason'));
+      return objectUnderTest.downloadDocumentation().catch(() => {
+        done();
+      });
+    });
+  });
+});

--- a/src/downloadDocumentation.spec.js
+++ b/src/downloadDocumentation.spec.js
@@ -28,9 +28,9 @@ describe('ServerlessAWSDocumentation', function () {
   });
 
   describe('downloadDocumentation', () => {
-    it('should successfully download documentation', (done) => {
+    it('should successfully download documentation, unknown file extension', (done) => {
       objectUnderTest.options = {
-        outputFileName: 'test.json',
+        outputFileName: 'test.txt',
       };
       objectUnderTest._getRestApiId = () => {
         return Promise.resolve('testRestApiId')
@@ -40,7 +40,37 @@ describe('ServerlessAWSDocumentation', function () {
         body: 'some body',
       }));
       return objectUnderTest.downloadDocumentation().then(() => {
-        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.json', 'some body');
+        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+          stageName: 'testStage',
+          restApiId: 'testRestApiId',
+          exportType: 'swagger',
+          accepts: 'application/json',
+        });
+        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.txt', 'some body');
+
+        done();
+      });
+    });
+
+    it('should successfully download documentation, yaml extension', (done) => {
+      objectUnderTest.options = {
+        outputFileName: 'test.yml',
+      };
+      objectUnderTest._getRestApiId = () => {
+        return Promise.resolve('testRestApiId')
+      };
+
+      objectUnderTest.serverless.providers.aws.request.and.returnValue(Promise.resolve({
+        body: 'some body',
+      }));
+      return objectUnderTest.downloadDocumentation().then(() => {
+        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+          stageName: 'testStage',
+          restApiId: 'testRestApiId',
+          exportType: 'swagger',
+          accepts: 'application/yaml',
+        });
+        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.yml', 'some body');
 
         done();
       });

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 const documentation = require('./documentation');
 const models = require('./models');
 const fs = require('fs');
-const downloadDocumentation = require('./downloadDocumentation')
+const downloadDocumentation = require('./downloadDocumentation');
 
 class ServerlessAWSDocumentation {
   constructor(serverless, options) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,15 @@
 'use strict';
 const documentation = require('./documentation');
 const models = require('./models');
+const fs = require('fs');
+const downloadDocumentation = require('./downloadDocumentation')
 
 class ServerlessAWSDocumentation {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    this.provider = 'aws'
+    this.provider = 'aws';
+    this.fs = fs;
 
     Object.assign(this, models);
     Object.assign(this, documentation());
@@ -18,13 +21,29 @@ class ServerlessAWSDocumentation {
 
     this._beforeDeploy = this.beforeDeploy.bind(this)
     this._afterDeploy = this.afterDeploy.bind(this)
+    this._download = downloadDocumentation.downloadDocumentation.bind(this)
 
     this.hooks = {
       'before:package:finalize': this._beforeDeploy,
       'after:deploy:deploy': this._afterDeploy,
+      'downloadDocumentation:downloadDocumentation': this._download
     };
 
     this.documentationParts = [];
+
+    this.commands = {
+        downloadDocumentation: {
+            usage: 'Download API Gateway documentation from AWS',
+            lifecycleEvents: [
+              'downloadDocumentation',
+            ],
+            options: {
+                outputFileName: {
+                    required: true,
+                },
+            },
+        }
+    };
   }
 
   beforeDeploy() {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -84,6 +84,7 @@ describe('ServerlessAWSDocumentation', function () {
       expect(this.plugin.hooks).toEqual({
         'before:package:finalize': this.plugin._beforeDeploy,
         'after:deploy:deploy': this.plugin._afterDeploy,
+        'downloadDocumentation:downloadDocumentation': this.plugin._download,
       });
     });
 
@@ -564,100 +565,6 @@ describe('ServerlessAWSDocumentation', function () {
             Description: 'API ID',
             Value: {
               Ref: 'ApiGatewayRestApi',
-            },
-          }
-        },
-      });
-    });
-
-    it('should use the provider rest api id', function () {
-      this.serverlessMock.variables.service.custom.documentation.models = [{
-        name: 'CreateResponseJson',
-        contentType: "application/json",
-        schema: {
-          type: 'object'
-        }
-      }];
-      this.serverlessMock.service._functionNames = ['test'];
-      this.serverlessMock.service._functions = {
-        test: {
-          events: [{
-            http: {
-              path: 'some/path',
-              method: 'post',
-              cors: true,
-              private: true,
-              documentation: {
-                methodResponses: [
-                  {
-                    statusCode: 200,
-                    responseModels: {
-                      'application/json': 'CreateResponseJson',
-                    },
-                    responseHeaders: [{
-                      name: 'x-header',
-                      description: 'THE header',
-                    }],
-                  },
-                ],
-              }
-            },
-          }],
-        },
-      };
-      this.serverlessMock.service.provider.apiGateway = {
-        restApiId: {
-          'Fn::ImportValue': 'PublicApiGatewayRestApi'
-        }
-      };
-
-      const resources = this.serverlessMock.service.provider.compiledCloudFormationTemplate.Resources;
-      resources.somepath_post = {
-        some: 'configuration',
-        Properties: {},
-      };
-
-      this.plugin.beforeDeploy();
-
-      expect(this.serverlessMock.service.provider.compiledCloudFormationTemplate).toEqual({
-        Resources: {
-          ExistingResource: {
-            with: 'configuration',
-          },
-          somepath_post: {
-            some: 'configuration',
-            DependsOn: ['CreateResponseJsonModel'],
-            Properties: {
-              MethodResponses: [{
-                StatusCode: '200',
-                ResponseModels: {
-                  'application/json': 'CreateResponseJson',
-                },
-                ResponseParameters: {
-                  'method.response.header.x-header': true,
-                },
-              }],
-            },
-          },
-          CreateResponseJsonModel: {
-            Type: 'AWS::ApiGateway::Model',
-            Properties: {
-              RestApiId: {
-                'Fn::ImportValue': 'PublicApiGatewayRestApi'
-              },
-              ContentType: 'application/json',
-              Name: 'CreateResponseJson',
-              Schema: {
-                type: 'object'
-              }
-            }
-          },
-        },
-        Outputs: {
-          AwsDocApiId: {
-            Description: 'API ID',
-            Value: {
-              'Fn::ImportValue': 'PublicApiGatewayRestApi',
             },
           }
         },

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -571,6 +571,100 @@ describe('ServerlessAWSDocumentation', function () {
       });
     });
 
+    it('should use the provider rest api id', function () {
+      this.serverlessMock.variables.service.custom.documentation.models = [{
+        name: 'CreateResponseJson',
+        contentType: "application/json",
+        schema: {
+          type: 'object'
+        }
+      }];
+      this.serverlessMock.service._functionNames = ['test'];
+      this.serverlessMock.service._functions = {
+        test: {
+          events: [{
+            http: {
+              path: 'some/path',
+              method: 'post',
+              cors: true,
+              private: true,
+              documentation: {
+                methodResponses: [
+                  {
+                    statusCode: 200,
+                    responseModels: {
+                      'application/json': 'CreateResponseJson',
+                    },
+                    responseHeaders: [{
+                      name: 'x-header',
+                      description: 'THE header',
+                    }],
+                  },
+                ],
+              }
+            },
+          }],
+        },
+      };
+      this.serverlessMock.service.provider.apiGateway = {
+        restApiId: {
+          'Fn::ImportValue': 'PublicApiGatewayRestApi'
+        }
+      };
+
+      const resources = this.serverlessMock.service.provider.compiledCloudFormationTemplate.Resources;
+      resources.somepath_post = {
+        some: 'configuration',
+        Properties: {},
+      };
+
+      this.plugin.beforeDeploy();
+
+      expect(this.serverlessMock.service.provider.compiledCloudFormationTemplate).toEqual({
+        Resources: {
+          ExistingResource: {
+            with: 'configuration',
+          },
+          somepath_post: {
+            some: 'configuration',
+            DependsOn: ['CreateResponseJsonModel'],
+            Properties: {
+              MethodResponses: [{
+                StatusCode: '200',
+                ResponseModels: {
+                  'application/json': 'CreateResponseJson',
+                },
+                ResponseParameters: {
+                  'method.response.header.x-header': true,
+                },
+              }],
+            },
+          },
+          CreateResponseJsonModel: {
+            Type: 'AWS::ApiGateway::Model',
+            Properties: {
+              RestApiId: {
+                'Fn::ImportValue': 'PublicApiGatewayRestApi'
+              },
+              ContentType: 'application/json',
+              Name: 'CreateResponseJson',
+              Schema: {
+                type: 'object'
+              }
+            }
+          },
+        },
+        Outputs: {
+          AwsDocApiId: {
+            Description: 'API ID',
+            Value: {
+              'Fn::ImportValue': 'PublicApiGatewayRestApi',
+            },
+          }
+        },
+      });
+    });
+
     it('should only add response methods with existing MethodResponses to ApiGateway methods', function () {
       this.serverlessMock.variables.service.custom.documentation.models = [];
       this.serverlessMock.service._functionNames = ['test'];


### PR DESCRIPTION
New feature: Download documentation from AWS Api Gateway
usage: 
```
serverless downloadDocumentation --outputFile=filename.json
```
