### PR TITLE
Fix documentation download

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ class ServerlessAWSDocumentation {
 
     Object.assign(this, models);
     Object.assign(this, documentation());
+    Object.assign(this, downloadDocumentation);
 
     this.customVars = this.serverless.variables.service.custom;
     const naming = this.serverless.providers.aws.naming;


### PR DESCRIPTION
Fix of a bug `this._getRestApiId is not a function` introduced in https://github.com/9cookies/serverless-aws-documentation/pull/80